### PR TITLE
I2310

### DIFF
--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -2,6 +2,8 @@
 
 set -e
 
+CHANNEL=${CHANNEL:-monitor-hook}
+
 apt-get update
 apt-get install -y unattended-upgrades curl
 
@@ -36,9 +38,9 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     export VAULT_AUTH_GITHUB_TOKEN=${token}
 fi
 vault login -method=github
-SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
+SLACK_WEBHOOK=$(vault read -field=value secret/slack/$(CHANNEL))
 
-cat <<EOF > /usr/local/sbin/check_reboot_required.sh
+cat <<EOF > /etc/cron.daily/check_reboot_required
 #!/bin/sh
 
 if [ -f /var/run/reboot-required ]; then
@@ -52,11 +54,9 @@ if [ -f /var/run/reboot-required ]; then
     hostname="annex"
   fi
 
-  curl -X POST -H 'Content-type: application/json' -d "{ \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
+  curl -X POST -H 'Content-type: application/json' -d "{ \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
 
 fi
 EOF
 
-chmod 755 /usr/local/sbin/check_reboot_required.sh
-
-crontab -l | { cat; echo "00 00 * * * /usr/local/sbin/check_reboot_required.sh"; } | crontab -
+chmod 755 /etc/cron.daily/check_reboot_required

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -38,7 +38,7 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     export VAULT_AUTH_GITHUB_TOKEN=${token}
 fi
 vault login -method=github
-SLACK_WEBHOOK=$(vault read -field=value secret/slack/$(CHANNEL))
+SLACK_WEBHOOK=$(vault read -field=value secret/slack/$CHANNEL)
 
 cat <<EOF > /etc/cron.daily/check_reboot_required
 #!/bin/sh

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -36,7 +36,7 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     export VAULT_AUTH_GITHUB_TOKEN=${token}
 fi
 vault login -method=github
-SLACK_WEBHOOK=$(vault read -field=password secret/slack/autoupdate-webhook)
+SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
 
 cat <<EOF > /usr/local/sbin/check_reboot_required.sh
 #!/bin/sh

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -2,7 +2,7 @@
 
 set -e
 
-CHANNEL=${CHANNEL:-monitor-hook}
+CHANNEL=${CHANNEL:-montagu-monitor}
 
 apt-get update
 apt-get install -y unattended-upgrades curl
@@ -38,7 +38,7 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     export VAULT_AUTH_GITHUB_TOKEN=${token}
 fi
 vault login -method=github
-SLACK_WEBHOOK=$(vault read -field=value secret/slack/$CHANNEL)
+SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
 
 cat <<EOF > /etc/cron.daily/check_reboot_required
 #!/bin/sh
@@ -54,7 +54,7 @@ if [ -f /var/run/reboot-required ]; then
     hostname="annex"
   fi
 
-  curl -X POST -H 'Content-type: application/json' -d "{ \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
+  curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
 
 fi
 EOF


### PR DESCRIPTION
See original scripts: https://vimc.myjetbrains.com/youtrack/issue/VIMC-2160 
and https://vimc.myjetbrains.com/youtrack/issue/VIMC-2310

Changes to one file, provision/setup-automatic-updates in this PR:

* Use monitor-webhook by default, but read CHANNEL environment variable for an alternative - (eg, test-webhook)
* Remove ".sh" from all refs to check_reboot_daily.sh
* Write that file to /etc/cron.daily instead of /usr/local/sbin (hence, no need for crontab line)
* Add suitable emoji and username to the JSON slack-webhook call.

I have applied the changes manually to production, support and annex, so that they all now have the newly created /etc/cron.daily/check_reboot_daily, and empty crontab.

Thanks @richfitz 