### PR TITLE
I2310-2 - change #1 in cron.daily file

### DIFF
--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -41,11 +41,11 @@ vault login -method=github
 SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
 
 cat <<EOF > /etc/cron.daily/check_reboot_required
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -f /var/run/reboot-required ]; then
 
-  hostname=\$(/bin/uname -n)
+  hostname=\$(uname -n)
   if [ \$hostname = "fi--didevimc01" ]; then
     hostname="production"
   elif [ \$hostname = "fi--didevimc02" ]; then
@@ -54,7 +54,7 @@ if [ -f /var/run/reboot-required ]; then
     hostname="annex"
   fi
 
-  /usr/bin/curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
+  curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
 
 fi
 EOF

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -45,7 +45,7 @@ cat <<EOF > /etc/cron.daily/check_reboot_required
 
 if [ -f /var/run/reboot-required ]; then
 
-  hostname=\$(uname -n)
+  hostname=\$(/bin/uname -n)
   if [ \$hostname = "fi--didevimc01" ]; then
     hostname="production"
   elif [ \$hostname = "fi--didevimc02" ]; then
@@ -54,7 +54,7 @@ if [ -f /var/run/reboot-required ]; then
     hostname="annex"
   fi
 
-  curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
+  /usr/bin/curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
 
 fi
 EOF


### PR DESCRIPTION
Using #!/usr/bin/env/bash in the script called from cron.daily, instead of #!/bin/sh appears to be necessary for things to work well. Everyone loves cron.

Thanks @richfitz 