### PR TITLE
i2497: Set up a montagu user on support and move docker services there

### DIFF
--- a/docs/Support.md
+++ b/docs/Support.md
@@ -13,6 +13,13 @@ Host fingerprint (ECDSA): `SHA256:etgLOXa8brU/0SsfYfoFwsNW3ljbkLPd3okPJlICN6A`
 * [Vault](https://github.com/vimc/montagu-vault) (as Docker container)
 * [Montagu-Monitor](https://github.com/vimc/montagu-monitor)
 
+## Users
+
+* The `vagrant` user is needed to control the virtual machines - `science`, `uat`, `latest`, and the CI system.
+* The `montagu` user is used to control services that are dockerised (though these can also be controlled from fresh clones in any user's directory)
+
+The passwords for these users are in the vault at `/secret/support/passwords/<user>` (stored under the `value` key), but these should be unnecessary for almost all actions.
+
 ## Upgrading and rebooting
 ### Graceful shutdown
 Everything will shutdown gracefully on host system shutdown. The Vagrant VMs

--- a/docs/Support.md
+++ b/docs/Support.md
@@ -4,14 +4,15 @@ support.montagu.dide.ic.ac.uk
 Host fingerprint (ECDSA): `SHA256:etgLOXa8brU/0SsfYfoFwsNW3ljbkLPd3okPJlICN6A`
 
 ## Services
+
 * [TeamCity](https://github.com/vimc/montagu-ci) 
   (via vagrant, installed as a systemd service as `montagu-ci`)
 * [Staging](https://github.com/vimc/montagu-machine/tree/master/staging)
   (via vagrant, installed as a systemd service as `montagu-staging`)
 * [Docker registry](https://github.com/vimc/montagu-registry) 
-  (as Docker container)
-* [Vault](https://github.com/vimc/montagu-vault) (as Docker container)
-* [Montagu-Monitor](https://github.com/vimc/montagu-monitor)
+  (as Docker container, control from `~montagu/registry`)
+* [Vault](https://github.com/vimc/montagu-vault) (as Docker container, control from `~montagu/vault`)
+* [Montagu-Monitor](https://github.com/vimc/montagu-monitor) (as Docker container, control from `~montagu/monitor`)
 
 ## Users
 
@@ -47,4 +48,3 @@ You can check things are working by:
 1. Staging: Browsing to the instances: [URLs](https://github.com/vimc/montagu/blob/master/staging/README.md#access-the-stage-instances)
 1. Vault: If you were able to unseal it, then it's up
 1. Monitor: Go to http://support.montagu.dide.ic.ac.uk:9090/
-


### PR DESCRIPTION
For https://github.com/vimc/montagu-monitor/pull/16

No code here, just documenting what I have done. This follows more closely the model that we have been using on annex and I think is a bit tidier