### PR TITLE
Vimc 3561 - update provisioning script for reboot webhook

### DIFF
--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -31,7 +31,7 @@ APT::Periodic::Verbose 2;
 APT::Periodic::RandomSleep 1;
 EOF
 
-# The next section can be deprecated if we stop using slack.
+# The next section should be deleted if we stop using slack.
 
 export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200
 if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -71,9 +71,13 @@ if [ -f /var/run/reboot-required ]; then
   fi
 
 # For slack:
+
   curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
+
 # For teams:
+
   curl -H 'Content-type: application/json' -d "{ \"channel\":\"#$TEAMS_CHANNEL\", \"text\":\" \", \"title\":\"Reboot required on "${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://outlook.office.com/webhook/$TEAMS_WEBHOOK
+
 fi
 EOF
 

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -3,6 +3,7 @@
 set -e
 
 CHANNEL=${CHANNEL:-montagu-reboot}
+TEAMS_CHANNEL=${CHANNEL:-bot-reboot}
 
 apt-get update
 apt-get install -y unattended-upgrades curl
@@ -30,6 +31,8 @@ APT::Periodic::Verbose 2;
 APT::Periodic::RandomSleep 1;
 EOF
 
+# The next section can be deprecated if we stop using slack.
+
 export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200
 if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     echo -n "Please provide your GitHub personal access token for the vault: "
@@ -39,6 +42,19 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
 fi
 vault login -method=github
 SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
+
+# This section is for Microsoft Teams, using the departmental vault server.
+
+export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
+if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
+    echo -n "Please provide your GitHub personal access token for the vault: "
+    read -s token
+    echo ""
+    export VAULT_AUTH_GITHUB_TOKEN=${token}
+fi
+vault login -method=github
+TEAMS_WEBHOOK=$(vault read -field=value secret/reside/teams/reboot-monitor-webhook)
+
 
 cat <<EOF > /etc/cron.daily/check_reboot_required
 #!/usr/bin/env bash
@@ -54,9 +70,12 @@ if [ -f /var/run/reboot-required ]; then
     hostname="annex"
   fi
 
+# For slack:
   curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
-
+# For teams:
+  curl -H 'Content-type: application/json' -d "{ \"channel\":\"#$TEAMS_CHANNEL\", \"text\":\" \", \"title\":\"Reboot required on "${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://outlook.office.com/webhook/$TEAMS_WEBHOOK
 fi
 EOF
 
-chmod 755 /etc/cron.daily/check_reboot_required
+
+fi

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -77,5 +77,4 @@ if [ -f /var/run/reboot-required ]; then
 fi
 EOF
 
-
-fi
+chmod 755 /etc/cron.daily/check_reboot_required


### PR DESCRIPTION
This now includes the code that would install the Microsoft Teams hook.

I can't quite remember how line 5 works - whether this script takes CHANNEL as an argument when used in the wild. If so, we'll need to delete the slack-specific code, for this to finally work, since the channels have different names now...

Not quite sure how you test this as a provisioning script - I have manually put the output I believe it will cause onto annex- will see if we get a nice message in the morning, since Annex needs rebooting at the moment...