### PR TITLE
Update auto-update script

### DIFF
--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -31,53 +31,22 @@ APT::Periodic::Verbose 2;
 APT::Periodic::RandomSleep 1;
 EOF
 
-# The next section should be deleted if we stop using slack.
-
-export VAULT_ADDR=https://support.montagu.dide.ic.ac.uk:8200
-if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
-    echo -n "Please provide your GitHub personal access token for the vault: "
-    read -s token
-    echo ""
-    export VAULT_AUTH_GITHUB_TOKEN=${token}
-fi
-vault login -method=github
-SLACK_WEBHOOK=$(vault read -field=value secret/slack/monitor-webhook)
-
-# This section is for Microsoft Teams, using the departmental vault server.
-
-export VAULT_ADDR=https://vault.dide.ic.ac.uk:8200
-if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
-    echo -n "Please provide your GitHub personal access token for the vault: "
-    read -s token
-    echo ""
-    export VAULT_AUTH_GITHUB_TOKEN=${token}
-fi
-vault login -method=github
-TEAMS_WEBHOOK=$(vault read -field=value secret/reside/teams/reboot-monitor-webhook)
-
-
 cat <<EOF > /etc/cron.daily/check_reboot_required
 #!/usr/bin/env bash
 
+hostname=\$(uname -n)
+if [ \$hostname = "fi--didevimc01" ]; then
+  hostname="production"
+elif [ \$hostname = "fi--didevimc02" ]; then
+  hostname="support"
+elif [ \$hostname = "wpia-didess1" ]; then
+  hostname="annex"
+fi
+
 if [ -f /var/run/reboot-required ]; then
-
-  hostname=\$(uname -n)
-  if [ \$hostname = "fi--didevimc01" ]; then
-    hostname="production"
-  elif [ \$hostname = "fi--didevimc02" ]; then
-    hostname="support"
-  elif [ \$hostname = "wpia-didess1" ]; then
-    hostname="annex"
-  fi
-
-# For slack:
-
-  curl -X POST -H 'Content-type: application/json' -d "{ \"channel\":\"#$CHANNEL\", \"username\":\"reboot-bot\", \"icon_emoji\":\":boot:\", \"text\":\"A reboot is required on "\${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://hooks.slack.com/services/$SLACK_WEBHOOK
-
-# For teams:
-
-  curl -H 'Content-type: application/json' -d "{ \"channel\":\"#$TEAMS_CHANNEL\", \"text\":\" \", \"title\":\"Reboot required on "${hostname}".montagu.dide.ic.ac.uk following automatic updates.\"}" https://outlook.office.com/webhook/$TEAMS_WEBHOOK
-
+  curl "https://mrcdata.dide.ic.ac.uk/monitor/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=1"
+else
+  curl "https://mrcdata.dide.ic.ac.uk/monitor/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=0"
 fi
 EOF
 

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -41,9 +41,9 @@ elif [ \$hostname = "wpia-didess1" ]; then
 fi
 
 if [ -f /var/run/reboot-required ]; then
-  curl "https://mrcdata.dide.ic.ac.uk/monitor/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=1"
+  curl "https://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=1"
 else
-  curl "https://mrcdata.dide.ic.ac.uk/monitor/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=0"
+  curl "https://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=0"
 fi
 EOF
 

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -41,9 +41,9 @@ elif [ \$hostname = "wpia-didess1" ]; then
 fi
 
 if [ -f /var/run/reboot-required ]; then
-  curl "https://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=1"
+  curl "http://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=1"
 else
-  curl "https://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=0"
+  curl "http://monitor.dide.ic.ac.uk/?machine=\${hostname}.montagu.dide.ic.ac.uk&status=0"
 fi
 EOF
 

--- a/provision/setup-automatic-updates
+++ b/provision/setup-automatic-updates
@@ -2,9 +2,6 @@
 
 set -e
 
-CHANNEL=${CHANNEL:-montagu-reboot}
-TEAMS_CHANNEL=${CHANNEL:-bot-reboot}
-
 apt-get update
 apt-get install -y unattended-upgrades curl
 


### PR DESCRIPTION
Regarding sending "I want a reboot" messages: 

This PR updates the deployment for all VIMC machines from separately sending messages to the reboot channel on Teams (and Slack), to instead submitting to a reboot monitor on mrcdata which packages all the reports together and sends as a single report message (for Teams only, since we're no longer using, or encouraging usage of Slack).

Auth with vault/looking up the webhook address is no longer required on "client" machines, and is only needed once when setting up the monitor on mrcdata - see https://github.com/reside-ic/reboot-monitor (in which I currently feed it the webhook once on setup without using vault programattically - that could be improved, but that's a separate issue...)