### PR TITLE
Update ubuntu version to 20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 Vagrant.require_version ">= 2.2.3"
 
 domain = 'localdomain'
-box = "bento/ubuntu-16.04"
+box = "bento/ubuntu-20.04"
 data_disk_size_gb = 900
 
 vault_config_file = 'staging/shared/vault_config'

--- a/provision/setup-montagu
+++ b/provision/setup-montagu
@@ -41,6 +41,7 @@ if [ -d montagu ]; then
 else
     echo "setting up montagu"
     git clone --recursive --branch update-psycopg2 https://github.com/vimc/montagu ${MONTAGU_PATH}
+    apt-get install -y libpq-dev
     pip3 install --user -r ${MONTAGU_PATH}/src/requirements.txt
     cp ${MONTAGU_PATH}/settings/${CONFIG_NAME}.json \
        ${MONTAGU_PATH}/src/montagu-deploy.json

--- a/provision/setup-montagu
+++ b/provision/setup-montagu
@@ -40,7 +40,7 @@ if [ -d montagu ]; then
     echo "montagu already set up"
 else
     echo "setting up montagu"
-    git clone --recursive https://github.com/vimc/montagu ${MONTAGU_PATH}
+    git clone --recursive --branch update-psycopg2 https://github.com/vimc/montagu ${MONTAGU_PATH}
     pip3 install --user -r ${MONTAGU_PATH}/src/requirements.txt
     cp ${MONTAGU_PATH}/settings/${CONFIG_NAME}.json \
        ${MONTAGU_PATH}/src/montagu-deploy.json

--- a/provision/setup-montagu
+++ b/provision/setup-montagu
@@ -41,7 +41,7 @@ if [ -d montagu ]; then
 else
     echo "setting up montagu"
     git clone --recursive --branch update-psycopg2 https://github.com/vimc/montagu ${MONTAGU_PATH}
-    apt-get install -y libpq-dev
+    sudo apt-get install -y libpq-dev
     pip3 install --user -r ${MONTAGU_PATH}/src/requirements.txt
     cp ${MONTAGU_PATH}/settings/${CONFIG_NAME}.json \
        ${MONTAGU_PATH}/src/montagu-deploy.json

--- a/provision/setup-montagu
+++ b/provision/setup-montagu
@@ -40,7 +40,7 @@ if [ -d montagu ]; then
     echo "montagu already set up"
 else
     echo "setting up montagu"
-    git clone --recursive --branch update-psycopg2 https://github.com/vimc/montagu ${MONTAGU_PATH}
+    git clone --recursive https://github.com/vimc/montagu ${MONTAGU_PATH}
     sudo apt-get install -y libpq-dev
     pip3 install --user -r ${MONTAGU_PATH}/src/requirements.txt
     cp ${MONTAGU_PATH}/settings/${CONFIG_NAME}.json \

--- a/provision/setup-pip
+++ b/provision/setup-pip
@@ -7,4 +7,5 @@ else
     echo "installing pip (for Python 3)"
     sudo apt-get update
     sudo apt-get install -y python3-pip
+    sudo pip3 install --upgrade pip
 fi


### PR DESCRIPTION
I've deployed this to uat and been able to install `orderly-web` deploy tool (without all python 3.5 errors - see ticket for details) and then deploy orderly-web and run a report.