### PR TITLE
VIMC-4819 Update data disk size for Montagu VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.require_version ">= 2.2.3"
 
 domain = 'localdomain'
 box = "bento/ubuntu-20.04"
-data_disk_size_gb = 900
+data_disk_size_gb = 1200
 
 vault_config_file = 'staging/shared/vault_config'
 

--- a/staging/README.md
+++ b/staging/README.md
@@ -39,6 +39,35 @@ systemctl status montagu-staging         # short status, run as ordinary user
 sudo journalctl --unit montagu-staging   # full log, needs root
 ```
 
+## Rebuilding a VM (e.g. uat, science)
+
+First ensure that `staging/shared/vault_config` includes a valid
+`VAULT_AUTH_GITHUB_TOKEN` then:
+
+```shell
+vagrant destroy uat
+
+# [Optional] To also destroy the data volume - required if modifying
+# `data_disk_size_gb` but otherwise undesirable as it necessitates a full sync:
+VBoxManage list hdds
+VBoxManage closemedium disk <UUID of uat.vdi> --delete
+
+vagrant up uat
+```
+
+[OrderlyWeb](https://github.com/vimc/orderly-web/blob/master/ReleaseProcess.md#deploying-to-uat--science--production)
+then needs to be set up manually:
+```shell
+./uat.sh
+git clone git@github.com:vimc/orderly-web-deploy.git
+(cd orderly-web-deploy && python3 setup.py install --user)
+git clone git@github.com:vimc/montagu-orderly-web.git
+(cd montagu-orderly-web && ./setup uat && ./start)
+```
+See [orderly-web-deploy](https://github.com/vimc/orderly-web-deploy) and
+[montagu-orderly-web](https://github.com/vimc/montagu-orderly-web) for further
+details
+
 ## Troubleshooting
 
 ### Bringing up vms


### PR DESCRIPTION
Increase size of disk used for Docker volumes inside Vagrant VM. These volumes include the orderly store and PostgreSQL data. This change has been made in order to allow full mirroring of production data to uat/science. This requires surplus disk space during synchronisation of database data and recently failed on UAT. The increase is modest in order to work within the limits of available disk space on the support machine itself.

Also make it clear how to actually rebuild staging VMs, which is fairly obvious but apparently undocumented elsewhere.